### PR TITLE
Sphinxify #22

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,8 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+buildapi:
+	sphinx-apidoc -f ../clovek_ne_jezi_se -o source/api
+	@echo "Auto-generation of API documentation finished. " \
+		"The generated files are in 'source/api/'"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
-BUILDDIR      = build
+BUILDDIR      = $(SPHINX_BUILD_DIR)
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/scripts/build_docs.sh
+++ b/docs/scripts/build_docs.sh
@@ -1,0 +1,15 @@
+# Note: script must be run from docs directory
+
+if [[ "$(basename $PWD)"  = "docs" ]]; then
+    make buildapi
+    make html
+
+    # Open local index.html in browser
+    cd $LOCAL_BUILD_DIR/html
+    open ./index.html
+
+    cd -
+else
+    echo "Aborting: script must be run from docs directory"
+    echo "You are in $PWD"
+fi

--- a/docs/source/INSTALL.rst
+++ b/docs/source/INSTALL.rst
@@ -1,0 +1,22 @@
+#########################
+Installation instructions
+#########################
+
+*****************
+Local development
+*****************
+
+First create and enter a virtual environment a la `virtualenvwrapper`_, `conda`_ or your own favorite (if you use `venv`_, you will first have to clone and :code:`cd` into the repository as below so that your virtual environment files are in the right place).
+
+.. code-block:: bash
+
+  git clone https://github.com/munichpavel/clovek-ne-jezi-se
+  cd clovek-ne-jezi-se
+  pip install -r requirements.txt
+
+
+.. URLS
+
+.. _`venv`: https://docs.python.org/3/library/venv.html
+.. _`virtualenvwrapper`: https://virtualenvwrapper.readthedocs.io/en/latest/
+.. _`conda`: https://docs.conda.io/en/latest/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,10 @@ release = '0.0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'clovek-ne-jezi-se'
+copyright = '2020, Paul Larsen'
+author = 'Paul Larsen'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to clovek-ne-jezi-se's documentation!
    :caption: Contents:
 
    INSTALL
+   api
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. clovek-ne-jezi-se documentation master file, created by
+   sphinx-quickstart on Sat Nov 21 09:58:51 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to clovek-ne-jezi-se's documentation!
+=============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,8 @@ Welcome to clovek-ne-jezi-se's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   INSTALL
+
 
 
 Indices and tables


### PR DESCRIPTION
Add minimal version of Sphinx document creation. Closes #22.

In scope

* quickstart Sphinx setup 
* In-line code documentation published locally using sphinx.ext.autodoc
* convenience scripts as in https://github.com/munichpavel/fake-data-for-learning/tree/master/docs/scripts

Out of scope

* publish to platform (readthedocs, GitHub pages)