### PR TITLE
Fix move to space index error #32

### DIFF
--- a/clovek_ne_jezi_se/agents.py
+++ b/clovek_ne_jezi_se/agents.py
@@ -32,5 +32,4 @@ class HumanPlayer(Player):
 
         chosen_move_idx = int(input('Enter chosen move index: '))
         res = allowed_moves[chosen_move_idx]
-        print(f'\nYou selected move {res}')
         return res

--- a/clovek_ne_jezi_se/game_state.py
+++ b/clovek_ne_jezi_se/game_state.py
@@ -486,16 +486,19 @@ class GameState:
         advance_edges = list(nx.dfs_edges(
             player_subgraph_view, source=from_node_name, depth_limit=roll+1
         ))
-        to_node_name = advance_edges[roll-1][1]
-        to_node = self._graph.nodes[to_node_name]
-        to_space = BoardSpace(
-            kind=to_node['kind'],
-            idx=to_node['idx'],
-            occupied_by=to_node['occupied_by'],
-            allowed_occupants=to_node['allowed_occupants']
-        )
+        if roll > len(advance_edges):
+            return None
+        else:
+            to_node_name = advance_edges[roll-1][1]
+            to_node = self._graph.nodes[to_node_name]
+            to_space = BoardSpace(
+                kind=to_node['kind'],
+                idx=to_node['idx'],
+                occupied_by=to_node['occupied_by'],
+                allowed_occupants=to_node['allowed_occupants']
+            )
 
-        return to_space
+            return to_space
 
     def _get_player_subgraph_query_paramses(
         self, player_name: str

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -199,6 +199,7 @@ class TestGameState:
         player_prehome_indices[player_name] = \
             player_subgraph.nodes[player_prehome_node_name]['idx']
 
+    # Move tests
     @pytest.mark.parametrize(
         "roll,from_space,expected_to_space_kwargs",
         [
@@ -206,6 +207,21 @@ class TestGameState:
                 5, BoardSpace(
                     kind='waiting', idx=0, occupied_by='red',
                     allowed_occupants=['red', EMPTY_SYMBOL]
+                ),
+                None
+            ),
+            (
+                1, BoardSpace(
+                    kind='home', idx=3, occupied_by='red',
+                    allowed_occupants=['red', EMPTY_SYMBOL]
+                ),
+                None
+            ),
+            (
+                5, BoardSpace(
+                    kind='main', idx=player_prehome_indices['red'],
+                    occupied_by='red',
+                    allowed_occupants=player_names + [EMPTY_SYMBOL]
                 ),
                 None
             ),
@@ -271,34 +287,6 @@ class TestGameState:
                 from_space=from_space, to_space=expected_to_space
             )
 
-    @pytest.mark.parametrize(
-        'roll,from_space,Error',
-        [
-            (
-                1, BoardSpace(
-                    kind='home', idx=3, occupied_by='red',
-                    allowed_occupants=['red', EMPTY_SYMBOL]
-                ),
-                IndexError
-            ),
-            (
-                5, BoardSpace(
-                    kind='main', idx=player_prehome_indices['red'],
-                    occupied_by='red',
-                    allowed_occupants=player_names + [EMPTY_SYMBOL]
-                ),
-                IndexError
-            ),
-
-        ]
-    )
-    def test_move_factory_exceptions(
-        self, roll, from_space, Error
-    ):
-        with pytest.raises(Error):
-            self.game_state.move_factory(from_space, roll)
-
-    # Move tests
     @pytest.mark.parametrize(
         'roll,from_space,to_space,post_do_from_space,post_do_to_space',
         [


### PR DESCRIPTION
Closes #32.

Add logic to return None for to-spaces that would cause index errors in `GameState.move_factory`, and remove accompanying tests for move_factory exceptions, as they were all index errors as in the bug.